### PR TITLE
style: Update theme to match Redot Engine branding

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -104,7 +104,7 @@ const config: Config = {
           items: [
             {
               label: 'Blog',
-              to: 'https://blog.redotengine.org',
+              href: 'https://blog.redotengine.org',
             },
             {
               label: 'GitHub',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -167,9 +167,9 @@ a {
 }
 
 .alert--warning {
-  --ifm-alert-background-color: rgba(255, 107, 107, 0.1);
-  --ifm-alert-color: #ff6b6b;
-  border-left-color: #ff6b6b;
+  --ifm-alert-background-color: rgba(240, 173, 78, 0.1);
+  --ifm-alert-color: #f0ad4e;
+  border-left-color: #f0ad4e;
 }
 
 .alert--danger {


### PR DESCRIPTION
## Summary
- Force dark mode only (matching redotengine.org)
- Set primary accent color to Redot orange (#F28C38)
- Apply dark backgrounds consistent with main Redot site
- Add card hover effects with orange glow
- Style navbar, footer, sidebar, and scrollbar elements

Closes #2

## Screenshots
Theme now matches the dark aesthetic of https://redotengine.org with the signature orange accent color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Default theme switched to dark with the color-scheme toggle and OS preference disabled; comprehensive dark palette and UI styling applied across components and responsive breakpoints.
  * Site branding updated: navbar logo and social preview image replaced; logo alt text revised.
* **Chores**
  * Edit links updated to point to the repository master branch.
* **Documentation**
  * Blog/navigation link behavior adjusted to use direct href links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->