### PR TITLE
feat: Add Cloudflare Pages CI/CD and fix broken markdown

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,30 +3,54 @@ name: Deploy to Cloudflare Pages
 on:
   push:
     branches: [master]
-  pull_request_target:
-    branches: [master]
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
 
 permissions:
+  actions: read
   contents: read
   deployments: write
   pull-requests: write
 
 jobs:
   deploy:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository (push deployments)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js (push deployments)
+        if: github.event_name == 'push'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
       
-      - run: npm ci
-      - run: npm run build
+      - name: Install dependencies (push deployments)
+        if: github.event_name == 'push'
+        run: npm ci
+
+      - name: Build docs (push deployments)
+        if: github.event_name == 'push'
+        run: npm run build
+
+      - name: Download build artifact (PR previews)
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: docusaurus-build
+          path: build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Deploy to Cloudflare Pages
         id: deploy
@@ -34,19 +58,20 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy build --project-name=redot-docs-site --branch=${{ github.event.pull_request.head.ref || github.ref_name }}
+          command: pages deploy build --project-name=redot-docs-site --branch=${{ github.event_name == 'workflow_run' && format('pr-{0}', github.event.workflow_run.pull_requests[0].number) || github.ref_name }}
       
       - name: Comment PR with preview URL
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number
         uses: actions/github-script@v7
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         with:
           script: |
+            const prNumber = context.payload.workflow_run.pull_requests[0]?.number;
             const deployUrl = process.env.DEPLOY_URL;
-            if (deployUrl) {
+            if (prNumber && deployUrl) {
               await github.rest.issues.createComment({
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: `🚀 **Preview deployment ready!**\n\n🔗 ${deployUrl}`

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,31 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docusaurus-build
+          path: build
+          retention-days: 1


### PR DESCRIPTION
Closes #3

## Summary
- Add Cloudflare Pages deployment workflow via GitHub Actions
- Enable preview deployments for fork PRs using `pull_request_target`
- Fix malformed Tabs components in markdown files that were breaking the build
- Harden Docker image runtime by running as unprivileged `node` user

Note: doing Cloudflare instead of Coolify for now.

## Changes
- `.github/workflows/deploy.yml`: deploy on push to `dev`, preview deploys for PRs to `dev`, PR comment with preview link
- `docs/Contributing/Development/compiling/compiling_for_linuxbsd.md`: fix broken Tabs structure
- `docs/Contributing/Development/compiling/introduction_to_the_buildsystem.md`: move heading outside Tabs
- `docs/Contributing/Documentation/building_the_manual.md`: repair Tabs blocks and invalid link syntax
- `docusaurus.config.ts`: set `onBrokenLinks` to `warn` while migration is incomplete
- `Dockerfile`: run container as non-root `node` user
- `docker-compose.yml`: local container setup

## Verification
- Workflow tested on fork PR: preview URL comment is posted
- Cloudflare Pages deployment works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment pipeline to provide reliable PR preview builds and conditional preview deployments.
  * Split build/upload steps so PR previews are produced and retained separately from push builds.
  * Deployment notifications (PR comments) now appear only when a preview URL is available, reducing noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->